### PR TITLE
fix: remove unused eudist_pts import from vormap_interp

### DIFF
--- a/vormap_interp.py
+++ b/vormap_interp.py
@@ -41,8 +41,6 @@ import math
 import csv
 import xml.etree.ElementTree as ET
 
-from vormap import eudist_pts
-
 try:
     from scipy.spatial import Voronoi as ScipyVoronoi
     _HAS_SCIPY = True


### PR DESCRIPTION
Removes the unused from vormap import eudist_pts import in vormap_interp.py. The function is never referenced - the module uses local math.sqrt and scipy for distance calculations. This eliminates an unnecessary module-level dependency.