### PR TITLE
Fix: recompute bounds before Voronoi construction from perturbed/shifted points

### DIFF
--- a/vormap_stability.py
+++ b/vormap_stability.py
@@ -38,6 +38,18 @@ import vormap
 from vormap_viz import compute_regions, compute_region_stats
 
 
+def _recompute_bounds(data):
+    """Recompute and set global bounds from *data* so that
+    ``compute_regions`` works correctly for any point set.
+
+    Without this, perturbed points that fall outside the original bounds
+    produce silently incorrect Voronoi diagrams — cells near the boundary
+    get clipped to the stale search space.
+    """
+    s, n, w, e = vormap.compute_bounds(data)
+    vormap.set_bounds(s, n, w, e)
+
+
 # ── Data classes ─────────────────────────────────────────────────────
 
 @dataclass
@@ -263,7 +275,8 @@ def stability_analysis(
 
     rng = random.Random(seed)
 
-    # Compute baseline diagram
+    # Compute baseline diagram — set bounds from the actual data
+    _recompute_bounds(data)
     base_regions = compute_regions(data)
     base_stats = compute_region_stats(base_regions, data)
     base_lookup = {}
@@ -280,6 +293,11 @@ def stability_analysis(
     for _ in range(iterations):
         perturbed = _perturb_points(data, noise_radius, rng)
         try:
+            # Recompute bounds for the perturbed point set so the Voronoi
+            # diagram covers all displaced seeds.  Without this, seeds
+            # pushed outside the original bounding box produce clipped /
+            # missing cells.
+            _recompute_bounds(perturbed)
             p_regions = compute_regions(perturbed)
         except Exception:
             # If the entire diagram fails, skip this trial

--- a/vormap_temporal.py
+++ b/vormap_temporal.py
@@ -292,6 +292,11 @@ def _get_cell_areas(points):
     """
     if len(points) < 2:
         return {}
+    # Recompute bounds so that compute_regions covers all points —
+    # without this, snapshots whose extents differ from the initial
+    # data produce silently incorrect cell areas.
+    s, n, w, e = vormap.compute_bounds(points)
+    vormap.set_bounds(s, n, w, e)
     regions = compute_regions(points)
     areas = {}
     for seed, vertices in regions.items():


### PR DESCRIPTION
## Problem

\ormap_stability.stability_analysis()\ perturbs seed points by up to \
oise_radius\, and \ormap_temporal._get_cell_areas()\ processes arbitrary snapshot point sets — but neither recomputes the global bounding box (\IND_S/N/W/E\) before calling \compute_regions()\.

When perturbed seeds or new snapshots fall outside the original bounds, \compute_regions()\ silently clips or drops cells, producing incorrect area measurements and corrupting stability/temporal scores.

## Fix

Call \ormap.compute_bounds() + set_bounds()\ before every \compute_regions()\ call on a derived point set:

- **vormap_stability.py**: recompute bounds for both the baseline diagram and each perturbed trial
- **vormap_temporal.py**: recompute bounds in \_get_cell_areas()\ before building regions for each snapshot

## Impact

Without this fix, stability analysis with large \
oise_radius\ values (or data near bounding box edges) produces artificially low stability scores because boundary cells get clipped. Temporal analysis similarly miscalculates area changes between snapshots with different spatial extents.