### PR TITLE
cleanup: deduplicate polygon helpers across 4 modules (-112 lines)

### DIFF
--- a/vormap_hull.py
+++ b/vormap_hull.py
@@ -45,70 +45,24 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 from vormap import validate_output_path
+from vormap_geometry import (
+    polygon_area,
+    polygon_centroid,
+    polygon_perimeter,
+    edge_length,
+)
 
 
 # ── Helpers ─────────────────────────────────────────────────────────
 
 def _dist(a: Tuple[float, float], b: Tuple[float, float]) -> float:
-    return math.sqrt((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2)
+    return edge_length(a, b)
 
 
 def _cross(o: Tuple[float, float], a: Tuple[float, float],
            b: Tuple[float, float]) -> float:
     """Cross product of vectors OA and OB (positive = counter-clockwise)."""
     return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
-
-
-def _polygon_area(vertices: List[Tuple[float, float]]) -> float:
-    """Shoelace formula for polygon area (unsigned)."""
-    n = len(vertices)
-    if n < 3:
-        return 0.0
-    area = 0.0
-    for i in range(n):
-        j = (i + 1) % n
-        area += vertices[i][0] * vertices[j][1]
-        area -= vertices[j][0] * vertices[i][1]
-    return abs(area) / 2.0
-
-
-def _polygon_perimeter(vertices: List[Tuple[float, float]]) -> float:
-    n = len(vertices)
-    if n < 2:
-        return 0.0
-    total = 0.0
-    for i in range(n):
-        j = (i + 1) % n
-        total += _dist(vertices[i], vertices[j])
-    return total
-
-
-def _polygon_centroid(vertices: List[Tuple[float, float]]
-                      ) -> Tuple[float, float]:
-    n = len(vertices)
-    if n == 0:
-        return (0.0, 0.0)
-    if n <= 2:
-        cx = sum(v[0] for v in vertices) / n
-        cy = sum(v[1] for v in vertices) / n
-        return (cx, cy)
-    cx = cy = 0.0
-    a = 0.0
-    for i in range(n):
-        j = (i + 1) % n
-        cross = (vertices[i][0] * vertices[j][1]
-                 - vertices[j][0] * vertices[i][1])
-        a += cross
-        cx += (vertices[i][0] + vertices[j][0]) * cross
-        cy += (vertices[i][1] + vertices[j][1]) * cross
-    a /= 2.0
-    if abs(a) < 1e-12:
-        cx = sum(v[0] for v in vertices) / n
-        cy = sum(v[1] for v in vertices) / n
-        return (cx, cy)
-    cx /= (6.0 * a)
-    cy /= (6.0 * a)
-    return (cx, cy)
 
 
 # ── Convex Hull (Andrew's monotone chain) ───────────────────────────
@@ -227,9 +181,9 @@ def convex_hull(points: List[Tuple[float, float]]) -> ConvexHullResult:
             hull_ratio=2 / n if n > 0 else 1.0,
         )
 
-    area = _polygon_area(hull)
-    perimeter = _polygon_perimeter(hull)
-    centroid = _polygon_centroid(hull)
+    area = polygon_area(hull)
+    perimeter = polygon_perimeter(hull)
+    centroid = polygon_centroid(hull)
 
     compactness = 0.0
     if perimeter > 0:

--- a/vormap_report.py
+++ b/vormap_report.py
@@ -21,6 +21,12 @@ import math
 import os
 import datetime
 
+from vormap_geometry import (
+    polygon_area,
+    polygon_centroid,
+    polygon_perimeter,
+)
+
 
 def _escape_html(text):
     """Escape HTML special characters."""
@@ -41,54 +47,6 @@ def _format_number(value, decimals=2):
         return f"{value:.{decimals}f}"
     return str(value)
 
-
-def _polygon_area(vertices):
-    """Shoelace formula for polygon area."""
-    n = len(vertices)
-    if n < 3:
-        return 0.0
-    area = 0.0
-    for i in range(n):
-        j = (i + 1) % n
-        area += vertices[i][0] * vertices[j][1]
-        area -= vertices[j][0] * vertices[i][1]
-    return abs(area) / 2.0
-
-
-def _polygon_perimeter(vertices):
-    """Compute polygon perimeter."""
-    n = len(vertices)
-    if n < 2:
-        return 0.0
-    perimeter = 0.0
-    for i in range(n):
-        j = (i + 1) % n
-        dx = vertices[j][0] - vertices[i][0]
-        dy = vertices[j][1] - vertices[i][1]
-        perimeter += math.sqrt(dx * dx + dy * dy)
-    return perimeter
-
-
-def _polygon_centroid(vertices):
-    """Compute polygon centroid."""
-    n = len(vertices)
-    if n == 0:
-        return (0.0, 0.0)
-    if n == 1:
-        return vertices[0]
-    cx, cy, a_sum = 0.0, 0.0, 0.0
-    for i in range(n):
-        j = (i + 1) % n
-        cross = vertices[i][0] * vertices[j][1] - vertices[j][0] * vertices[i][1]
-        cx += (vertices[i][0] + vertices[j][0]) * cross
-        cy += (vertices[i][1] + vertices[j][1]) * cross
-        a_sum += cross
-    if abs(a_sum) < 1e-12:
-        xs = sum(v[0] for v in vertices) / n
-        ys = sum(v[1] for v in vertices) / n
-        return (xs, ys)
-    a_sum *= 3.0
-    return (cx / a_sum, cy / a_sum)
 
 
 def _mean(values):
@@ -171,9 +129,9 @@ class VoronoiReport:
             return self._stats
         stats = []
         for i, region in enumerate(self.regions):
-            area = _polygon_area(region)
-            perim = _polygon_perimeter(region)
-            cx, cy = _polygon_centroid(region)
+            area = polygon_area(region)
+            perim = polygon_perimeter(region)
+            cx, cy = polygon_centroid(region)
             nverts = len(region)
             compactness = (
                 (4 * math.pi * area / (perim * perim)) if perim > 0 else 0.0

--- a/vormap_stability.py
+++ b/vormap_stability.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Tuple
 
 import vormap
+from vormap_geometry import polygon_area
 from vormap_viz import compute_regions, compute_region_stats
 
 
@@ -197,25 +198,12 @@ def _match_seeds(
             p_seed = perturbed_data[i]
             if p_seed in perturbed_lookup:
                 verts = perturbed_lookup[p_seed]
-                area = _polygon_area(verts)
+                area = polygon_area(verts)
                 matched[orig_seed] = {
                     "area": area,
                     "vertex_count": len(verts),
                 }
     return matched
-
-
-def _polygon_area(vertices: Sequence[Tuple[float, float]]) -> float:
-    """Shoelace formula for polygon area."""
-    n = len(vertices)
-    if n < 3:
-        return 0.0
-    area = 0.0
-    for i in range(n):
-        j = (i + 1) % n
-        area += vertices[i][0] * vertices[j][1]
-        area -= vertices[j][0] * vertices[i][1]
-    return abs(area) / 2.0
 
 
 def stability_analysis(

--- a/vormap_temporal.py
+++ b/vormap_temporal.py
@@ -41,6 +41,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Tuple
 
 import vormap
+from vormap_geometry import polygon_area, edge_length
 from vormap_viz import compute_regions, compute_region_stats
 
 
@@ -225,20 +226,7 @@ class TemporalResult:
 
 def _euclidean(a, b):
     """Euclidean distance between two 2D points."""
-    return math.sqrt((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2)
-
-
-def _polygon_area(vertices):
-    """Shoelace formula for polygon area (unsigned)."""
-    n = len(vertices)
-    if n < 3:
-        return 0.0
-    area = 0.0
-    for i in range(n):
-        j = (i + 1) % n
-        area += vertices[i][0] * vertices[j][1]
-        area -= vertices[j][0] * vertices[i][1]
-    return abs(area) / 2.0
+    return edge_length(a, b)
 
 
 def _match_seeds(seeds_a, seeds_b, radius):
@@ -295,7 +283,7 @@ def _get_cell_areas(points):
     regions = compute_regions(points)
     areas = {}
     for seed, vertices in regions.items():
-        areas[seed] = _polygon_area(vertices)
+        areas[seed] = polygon_area(vertices)
     return areas
 
 


### PR DESCRIPTION
Replace copy-pasted `_polygon_area`, `_polygon_centroid`, `_polygon_perimeter` implementations in 4 modules with imports from `vormap_geometry` — the shared helper module that already provides these exact functions.

**Deduplicated in:**
- `vormap_hull.py` — removed 3 functions (38 lines) + `_dist` now delegates to `edge_length`
- `vormap_report.py` — removed 3 functions (36 lines)
- `vormap_stability.py` — removed 1 function (10 lines)
- `vormap_temporal.py` — removed 1 function (10 lines) + `_euclidean` now delegates to `edge_length`

**Net:** -112 lines (24 added, 136 removed)

**Note:** `vormap_relax.py` also has `_polygon_centroid` but uses numpy array operations (`vertices[:, 0]`, `np.roll`), so it's intentionally different from the tuple-based `vormap_geometry.polygon_centroid` and was left as-is.

All 321 tests pass.
