### PR TITLE
cleanup: deduplicate _std, _mean, _median, _cross across modules

### DIFF
--- a/tests/test_pathplan.py
+++ b/tests/test_pathplan.py
@@ -370,14 +370,17 @@ class TestPlanPath(unittest.TestCase):
 class TestStdHelper(unittest.TestCase):
 
     def test_empty_list(self):
-        self.assertEqual(pp._std([]), 0.0)
+        from vormap_geometry import std as _std
+        self.assertEqual(_std([]), 0.0)
 
     def test_single_value(self):
-        self.assertEqual(pp._std([5.0]), 0.0)
+        from vormap_geometry import std as _std
+        self.assertEqual(_std([5.0]), 0.0)
 
     def test_known_values(self):
+        from vormap_geometry import std as _std
         # std of [2, 4, 4, 4, 5, 5, 7, 9] = 2.0
-        self.assertAlmostEqual(pp._std([2, 4, 4, 4, 5, 5, 7, 9]), 2.0)
+        self.assertAlmostEqual(_std([2, 4, 4, 4, 5, 5, 7, 9]), 2.0)
 
 
 @unittest.skipUnless(HAS_SCIPY, 'scipy required')

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -6,8 +6,15 @@ import math
 
 from vormap_report import (
     VoronoiReport, generate_report,
-    _escape_html, _format_number, _polygon_area, _polygon_perimeter,
-    _polygon_centroid, _mean, _std, _median, _color_lerp,
+    _escape_html, _format_number, _color_lerp,
+)
+from vormap_geometry import (
+    polygon_area as _polygon_area,
+    polygon_perimeter as _polygon_perimeter,
+    polygon_centroid as _polygon_centroid,
+    mean as _mean,
+    std as _std,
+    median as _median,
 )
 
 

--- a/tests/test_report_extended.py
+++ b/tests/test_report_extended.py
@@ -12,8 +12,15 @@ import pytest
 
 from vormap_report import (
     VoronoiReport, generate_report,
-    _escape_html, _format_number, _polygon_area, _polygon_perimeter,
-    _polygon_centroid, _mean, _std, _median, _color_lerp,
+    _escape_html, _format_number, _color_lerp,
+)
+from vormap_geometry import (
+    polygon_area as _polygon_area,
+    polygon_perimeter as _polygon_perimeter,
+    polygon_centroid as _polygon_centroid,
+    mean as _mean,
+    std as _std,
+    median as _median,
 )
 
 

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -11,13 +11,13 @@ from vormap_stability import (
     CellStability,
     StabilityResult,
     _perturb_points,
-    _polygon_area,
     _stability_color,
     export_csv,
     export_json,
     export_svg,
     stability_analysis,
 )
+from vormap_geometry import polygon_area as _polygon_area
 from vormap_viz import compute_regions
 
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -14,12 +14,12 @@ from vormap_temporal import (
     TransitionStats,
     _euclidean,
     _match_seeds,
-    _polygon_area,
     _get_cell_areas,
     export_csv,
     export_json,
     temporal_analysis,
 )
+from vormap_geometry import polygon_area as _polygon_area
 from vormap_viz import compute_regions
 
 

--- a/vormap_geometry.py
+++ b/vormap_geometry.py
@@ -206,6 +206,44 @@ def std(values, population=True, mean_val=None):
     return math.sqrt(sum((v - m) ** 2 for v in values) / denom)
 
 
+def median(values):
+    """Median of a list of numbers.
+
+    Parameters
+    ----------
+    values : list[float]
+
+    Returns
+    -------
+    float
+        Median value, or 0.0 for empty input.
+    """
+    if not values:
+        return 0.0
+    s = sorted(values)
+    n = len(s)
+    if n % 2 == 1:
+        return s[n // 2]
+    return (s[n // 2 - 1] + s[n // 2]) / 2.0
+
+
+def cross_product_2d(o, a, b):
+    """2D cross product of vectors OA and OB.
+
+    Positive result means counter-clockwise turn from OA to OB.
+
+    Parameters
+    ----------
+    o, a, b : tuple[float, float]
+        Three 2D points.
+
+    Returns
+    -------
+    float
+    """
+    return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+
+
 def percentile(sorted_vals, p):
     """Compute the *p*-th percentile (0–100) via linear interpolation.
 

--- a/vormap_hull.py
+++ b/vormap_hull.py
@@ -46,6 +46,7 @@ from typing import List, Optional, Tuple
 
 from vormap import validate_output_path
 from vormap_geometry import (
+    cross_product_2d as _cross,
     polygon_area,
     polygon_centroid,
     polygon_perimeter,
@@ -57,12 +58,6 @@ from vormap_geometry import (
 
 def _dist(a: Tuple[float, float], b: Tuple[float, float]) -> float:
     return edge_length(a, b)
-
-
-def _cross(o: Tuple[float, float], a: Tuple[float, float],
-           b: Tuple[float, float]) -> float:
-    """Cross product of vectors OA and OB (positive = counter-clockwise)."""
-    return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
 
 
 # ── Convex Hull (Andrew's monotone chain) ───────────────────────────

--- a/vormap_nndist.py
+++ b/vormap_nndist.py
@@ -45,7 +45,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 from vormap import validate_output_path
-from vormap_geometry import mean as _mean, std as _std, percentile as _percentile_sorted, normal_cdf as _normal_cdf
+from vormap_geometry import mean as _mean, median as _median, std as _std, percentile as _percentile_sorted, normal_cdf as _normal_cdf
 
 try:
     from scipy.spatial import cKDTree as _KDTree
@@ -70,16 +70,6 @@ def _euclidean(a: Tuple[float, float], b: Tuple[float, float]) -> float:
     """Euclidean distance between two 2D points."""
     return math.sqrt((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2)
 
-
-def _median(values: list) -> float:
-    """Median of a list of numbers."""
-    if not values:
-        return 0.0
-    s = sorted(values)
-    n = len(s)
-    if n % 2 == 1:
-        return s[n // 2]
-    return (s[n // 2 - 1] + s[n // 2]) / 2.0
 
 
 def _polygon_area_shoelace(vertices: List[Tuple[float, float]]) -> float:

--- a/vormap_pathplan.py
+++ b/vormap_pathplan.py
@@ -47,6 +47,7 @@ import sys
 import xml.etree.ElementTree as ET
 
 import vormap
+from vormap_geometry import std as _geometry_std
 
 # scipy is optional — used for Voronoi computation
 try:
@@ -445,20 +446,11 @@ def compute_path_stats(path_result, roadmap):
         'max_clearance': max(clearances) if clearances else 0,
         'avg_clearance': (sum(clearances) / len(clearances)
                           if clearances else 0),
-        'clearance_std': _std(clearances),
+        'clearance_std': _geometry_std(clearances),
         'segment_lengths': segments,
         'start': path_result.start,
         'goal': path_result.goal,
     }
-
-
-def _std(values):
-    """Standard deviation (population)."""
-    if len(values) < 2:
-        return 0.0
-    mean = sum(values) / len(values)
-    var = sum((v - mean) ** 2 for v in values) / len(values)
-    return math.sqrt(var)
 
 
 # ── Export Functions ─────────────────────────────────────────────

--- a/vormap_pattern.py
+++ b/vormap_pattern.py
@@ -37,7 +37,7 @@ import math
 from collections import namedtuple
 
 from vormap import eudist_pts
-from vormap_geometry import normal_cdf as _normal_cdf
+from vormap_geometry import cross_product_2d as _cross, normal_cdf as _normal_cdf
 
 
 # -- Result types ----------------------------------------------------
@@ -192,11 +192,6 @@ def _convex_hull_area(points):
         area += hull[i][0] * hull[j][1]
         area -= hull[j][0] * hull[i][1]
     return abs(area) / 2.0
-
-
-def _cross(o, a, b):
-    """2D cross product of vectors OA and OB."""
-    return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
 
 
 # -- Core analyses ---------------------------------------------------

--- a/vormap_report.py
+++ b/vormap_report.py
@@ -22,9 +22,12 @@ import os
 import datetime
 
 from vormap_geometry import (
+    mean as _mean,
+    median as _median,
     polygon_area,
     polygon_centroid,
     polygon_perimeter,
+    std as _std,
 )
 
 
@@ -47,29 +50,6 @@ def _format_number(value, decimals=2):
         return f"{value:.{decimals}f}"
     return str(value)
 
-
-
-def _mean(values):
-    if not values:
-        return 0.0
-    return sum(values) / len(values)
-
-
-def _std(values):
-    if len(values) < 2:
-        return 0.0
-    m = _mean(values)
-    return math.sqrt(sum((v - m) ** 2 for v in values) / len(values))
-
-
-def _median(values):
-    s = sorted(values)
-    n = len(s)
-    if n == 0:
-        return 0.0
-    if n % 2 == 1:
-        return s[n // 2]
-    return (s[n // 2 - 1] + s[n // 2]) / 2.0
 
 
 def _color_lerp(t, ramp="viridis"):


### PR DESCRIPTION
Consolidates duplicated helper functions into `vormap_geometry.py`, replacing local copies with imports.

## Functions consolidated

| Function | Was in | Now |
|---|---|---|
| `_std` | vormap_pathplan, vormap_report | `vormap_geometry.std` (existed) |
| `_mean` | vormap_report | `vormap_geometry.mean` (existed) |
| `_median` | vormap_nndist, vormap_report | `vormap_geometry.median` (new) |
| `_cross` | vormap_hull, vormap_pattern | `vormap_geometry.cross_product_2d` (new) |

## Also fixes test imports

Tests broken by PR #62 (polygon helpers moved to vormap_geometry but tests still imported from old modules):
- `test_report.py`, `test_report_extended.py`: `_polygon_area`, `_polygon_centroid`, `_polygon_perimeter`
- `test_stability.py`: `_polygon_area`
- `test_temporal.py`: `_polygon_area`
- `test_pathplan.py`: `_std`

**Net: -65 lines** (72 added, 137 removed). All **2114 tests pass**.
