### PR TITLE
fix: include all 44 vormap modules in published package (was shipping only 2)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include requirements.txt
 include .coveragerc
 recursive-include tests *.py
 recursive-include docs *
+include vormap.py vormap_*.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "voronoimap"
-version = "1.0.0"
+version = "1.1.0"
 description = "Estimate aggregate statistics of unknown point sets using Voronoi partitioning and nearest-neighbor oracles"
 readme = "README.md"
 license = {text = "MIT"}
@@ -61,10 +61,55 @@ Issues = "https://github.com/sauravbhattacharya001/VoronoiMap/issues"
 Documentation = "https://sauravbhattacharya001.github.io/VoronoiMap/"
 
 [tool.setuptools]
-py-modules = ["vormap", "vormap_viz"]
+py-modules = [
+    "vormap",
+    "vormap_access",
+    "vormap_autocorr",
+    "vormap_clip",
+    "vormap_cluster",
+    "vormap_color",
+    "vormap_compare",
+    "vormap_coverage",
+    "vormap_edge",
+    "vormap_generate",
+    "vormap_geojson",
+    "vormap_geometry",
+    "vormap_graph",
+    "vormap_heatmap",
+    "vormap_hotspot",
+    "vormap_hull",
+    "vormap_interp",
+    "vormap_kde",
+    "vormap_kml",
+    "vormap_landscape",
+    "vormap_mapalgebra",
+    "vormap_merge",
+    "vormap_mosaic",
+    "vormap_network",
+    "vormap_nndist",
+    "vormap_outlier",
+    "vormap_pathplan",
+    "vormap_pattern",
+    "vormap_pipeline",
+    "vormap_power",
+    "vormap_query",
+    "vormap_regularity",
+    "vormap_relax",
+    "vormap_report",
+    "vormap_sample",
+    "vormap_seeds",
+    "vormap_stability",
+    "vormap_temporal",
+    "vormap_territory",
+    "vormap_transect",
+    "vormap_trend",
+    "vormap_variogram",
+    "vormap_viz",
+    "vormap_watershed",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
 [tool.coverage.run]
-source = ["vormap"]
+source = ["vormap", "vormap_access", "vormap_autocorr", "vormap_clip", "vormap_cluster", "vormap_color", "vormap_compare", "vormap_coverage", "vormap_edge", "vormap_generate", "vormap_geojson", "vormap_geometry", "vormap_graph", "vormap_heatmap", "vormap_hotspot", "vormap_hull", "vormap_interp", "vormap_kde", "vormap_kml", "vormap_landscape", "vormap_mapalgebra", "vormap_merge", "vormap_mosaic", "vormap_network", "vormap_nndist", "vormap_outlier", "vormap_pathplan", "vormap_pattern", "vormap_pipeline", "vormap_power", "vormap_query", "vormap_regularity", "vormap_relax", "vormap_report", "vormap_sample", "vormap_seeds", "vormap_stability", "vormap_temporal", "vormap_territory", "vormap_transect", "vormap_trend", "vormap_variogram", "vormap_viz", "vormap_watershed"]


### PR DESCRIPTION
Critical packaging bug: pyproject.toml only listed py-modules = ["vormap", "vormap_viz"], silently dropping 42 modules from the sdist/wheel. Anyone installing via pip install voronoimap would get a broken package missing interpolation, clustering, graph analysis, heatmap, KDE, etc.

Changes:
- Expand py-modules from 2 to 44 (all vormap_*.py source files)
- Add include vormap.py vormap_*.py to MANIFEST.in
- Update [tool.coverage.run] source to include all modules
- Bump version 1.0.0 to 1.1.0

Verified: python -m build --sdist produces voronoimap-1.1.0.tar.gz containing all 44 modules.
