### PR TITLE
fix: weighted_overlay weight normalisation bug + XSS in pipeline report

### DIFF
--- a/vormap_mapalgebra.py
+++ b/vormap_mapalgebra.py
@@ -633,9 +633,14 @@ def weighted_overlay(
         raise ValueError(f"Need {len(layers)} weights, got {len(weights)}")
     if not layers:
         raise ValueError("Need at least one layer")
+    if any(w < 0 for w in weights):
+        raise ValueError(
+            "Negative weights are not supported in weighted overlay. "
+            "All weights must be >= 0 (use local_subtract for inverse criteria)."
+        )
 
-    # Normalise weights
-    total_w = sum(abs(w) for w in weights)
+    # Normalise weights to sum to 1
+    total_w = sum(weights)
     if total_w == 0:
         raise ValueError("Weights cannot all be zero")
     norm_weights = [w / total_w for w in weights]


### PR DESCRIPTION
Two fixes:

1. **Bug fix**: \weighted_overlay()\ used \sum(abs(w))\ to normalise weights, which breaks the 'sum to 1' contract when negative weights are present (e.g. [3,-1,2] normalises to sum=0.667). Now uses \sum(weights)\ and rejects negative weights with a clear error.

2. **Security fix**: \_generate_html_report()\ rendered 6 user-derived values (pipeline name, data file, step type/status/key/message) without HTML escaping. Added \_esc()\ helper for XSS prevention.

All 2348 tests pass.