### PR TITLE
fix: add FRAGSTATS 0.25 perimeter normalization to _fractal_dimension

### DIFF
--- a/tests/test_landscape.py
+++ b/tests/test_landscape.py
@@ -424,6 +424,14 @@ class TestHelpers:
     def test_fractal_dim_zero_area(self):
         assert vormap_landscape._fractal_dimension(0, 100) == 0.0
 
+    def test_fractal_dim_square_patch(self):
+        """A perfect square (area=100, perimeter=40) should give FRAC=1.0."""
+        import math
+        result = vormap_landscape._fractal_dimension(100, 40)
+        expected = 2 * math.log(0.25 * 40) / math.log(100)  # 1.0
+        assert abs(result - expected) < 1e-10
+        assert abs(result - 1.0) < 1e-10
+
     def test_core_area_zero_depth(self):
         area = 10000
         perim = 400

--- a/vormap_landscape.py
+++ b/vormap_landscape.py
@@ -135,10 +135,16 @@ def _shape_index(area: float, perimeter: float) -> float:
 
 
 def _fractal_dimension(area: float, perimeter: float) -> float:
-    """Patch fractal dimension (perimeter-area relationship)."""
+    """Patch fractal dimension using FRAGSTATS formula.
+
+    FRAC = 2 * ln(0.25 * P) / ln(A)
+
+    The 0.25 normalization ensures a square patch yields FRAC = 1.0.
+    Reference: McGarigal et al. 2012, FRAGSTATS v4.
+    """
     if area <= 0 or perimeter <= 0:
         return 0.0
-    ln_p = math.log(perimeter)
+    ln_p = math.log(0.25 * perimeter)
     ln_a = math.log(area)
     if ln_a == 0:
         return 0.0


### PR DESCRIPTION
## Summary
Apply the standard FRAGSTATS perimeter normalization constant (0.25) to the patch fractal dimension formula.

**Before:** `FRAC = 2 * ln(P) / ln(A)` — overestimates all values
**After:** `FRAC = 2 * ln(0.25 * P) / ln(A)` — matches FRAGSTATS spec

A perfect square (area=100, perimeter=40) now correctly returns FRAC=1.0 instead of 1.60.

## Changes
- `vormap_landscape.py`: Add `0.25 *` normalization in `_fractal_dimension()`; update docstring
- `tests/test_landscape.py`: Add unit tests verifying square=1.0 and normalization applied

Ref: McGarigal, Cushman & Ene 2012, FRAGSTATS v4.

Closes #92