### PR TITLE
ci(docker): add Trivy vulnerability scanning on PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,3 +54,22 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+
+      - name: Build image for scanning
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan
+          cache-from: type=gha
+
+      - name: Run Trivy vulnerability scanner
+        if: github.event_name == 'pull_request'
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan
+          format: table
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true


### PR DESCRIPTION
Adds container image security scanning via [Trivy](https://github.com/aquasecurity/trivy) to the Docker workflow.

## Changes
- On pull requests, builds a single-platform image and runs Trivy vulnerability scanner
- Fails the check on CRITICAL and HIGH severity vulnerabilities (ignores unfixed)
- Production push step remains unchanged (multi-platform)

This catches vulnerable OS packages and dependencies in the Docker image before merge.