### PR TITLE
fix: index-based area storage to handle duplicate seed coordinates

### DIFF
--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1,0 +1,447 @@
+"""Tests for vormap_temporal -- Voronoi temporal dynamics analysis."""
+
+import json
+import math
+import os
+import tempfile
+
+import pytest
+
+from vormap_temporal import (
+    CellEvent,
+    CellTrajectory,
+    TemporalResult,
+    TransitionStats,
+    _euclidean,
+    _match_seeds,
+    _get_cell_areas,
+    export_csv,
+    export_json,
+    temporal_analysis,
+)
+from vormap_geometry import polygon_area as _polygon_area
+from vormap_viz import compute_regions
+
+
+# -- Test helpers -----------------------------------------------------
+
+def _make_grid(n=3, spacing=100.0, offset_x=0.0, offset_y=0.0):
+    """Create an n x n grid of points."""
+    return [
+        (x * spacing + offset_x, y * spacing + offset_y)
+        for x in range(n) for y in range(n)
+    ]
+
+
+def _shift_points(points, dx, dy):
+    """Shift all points by (dx, dy)."""
+    return [(p[0] + dx, p[1] + dy) for p in points]
+
+
+# -- Helper tests -----------------------------------------------------
+
+class TestEuclidean:
+    def test_same_point(self):
+        assert _euclidean((0, 0), (0, 0)) == 0.0
+
+    def test_unit_distance(self):
+        assert _euclidean((0, 0), (1, 0)) == 1.0
+
+    def test_diagonal(self):
+        d = _euclidean((0, 0), (3, 4))
+        assert abs(d - 5.0) < 1e-10
+
+    def test_negative_coords(self):
+        d = _euclidean((-1, -1), (2, 3))
+        assert abs(d - 5.0) < 1e-10
+
+
+class TestPolygonArea:
+    def test_triangle(self):
+        verts = [(0, 0), (4, 0), (0, 3)]
+        assert abs(_polygon_area(verts) - 6.0) < 1e-10
+
+    def test_square(self):
+        verts = [(0, 0), (2, 0), (2, 2), (0, 2)]
+        assert abs(_polygon_area(verts) - 4.0) < 1e-10
+
+    def test_degenerate(self):
+        assert _polygon_area([(0, 0), (1, 1)]) == 0.0
+        assert _polygon_area([]) == 0.0
+
+
+class TestMatchSeeds:
+    def test_identical_seeds(self):
+        seeds = [(0, 0), (100, 100), (200, 200)]
+        matches, deaths, births = _match_seeds(seeds, seeds, 10.0)
+        assert len(matches) == 3
+        assert deaths == []
+        assert births == []
+
+    def test_all_deaths(self):
+        a = [(0, 0), (100, 100)]
+        b = [(500, 500), (600, 600)]
+        matches, deaths, births = _match_seeds(a, b, 10.0)
+        assert len(matches) == 0
+        assert len(deaths) == 2
+        assert len(births) == 2
+
+    def test_partial_match(self):
+        a = [(0, 0), (100, 100), (200, 200)]
+        b = [(5, 5), (200, 200), (500, 500)]
+        matches, deaths, births = _match_seeds(a, b, 20.0)
+        assert 0 in matches  # (0,0) -> (5,5)
+        assert 2 in matches  # (200,200) -> (200,200)
+        assert 1 in deaths   # (100,100) unmatched
+        assert len(births) == 1  # (500,500) is new
+
+    def test_greedy_closest_first(self):
+        """Closer pairs should be matched first."""
+        a = [(0, 0), (8, 0)]
+        b = [(7, 0)]  # dist 7 from a[0], dist 1 from a[1]
+        matches, deaths, births = _match_seeds(a, b, 20.0)
+        # a[1]=(8,0) is closer to b[0]=(7,0) — should be matched
+        assert matches[1] == 0
+        assert 0 in deaths
+
+    def test_empty_lists(self):
+        matches, deaths, births = _match_seeds([], [], 10.0)
+        assert matches == {}
+        assert deaths == []
+        assert births == []
+
+
+class TestGetCellAreas:
+    def test_basic_grid(self):
+        points = _make_grid(3, 100.0)
+        areas = _get_cell_areas(points)
+        assert len(areas) > 0
+        for seed, area in areas.items():
+            assert area >= 0
+
+    def test_single_point(self):
+        areas = _get_cell_areas([(0, 0)])
+        assert areas == {}
+
+    def test_duplicate_coordinates_returns_all_indices(self):
+        """Duplicate seeds should each get their own index entry."""
+        points = [(100.0, 200.0), (100.0, 200.0), (300.0, 400.0)]
+        import warnings
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            areas = _get_cell_areas(points)
+            assert len(w) == 1
+            assert "Duplicate seed coordinate" in str(w[0].message)
+        # All three indices must be present
+        assert 0 in areas
+        assert 1 in areas
+        assert 2 in areas
+
+    def test_areas_keyed_by_index(self):
+        """Areas dict should be keyed by integer index, not tuple."""
+        points = [(0.0, 0.0), (100.0, 0.0), (50.0, 100.0)]
+        areas = _get_cell_areas(points)
+        for key in areas:
+            assert isinstance(key, int)
+
+
+# -- Core analysis tests ----------------------------------------------
+
+class TestTemporalAnalysis:
+    def test_identical_snapshots(self):
+        pts = _make_grid(3, 100.0)
+        result = temporal_analysis([pts, pts], match_radius=10.0)
+        assert result.num_snapshots == 2
+        assert result.overall_stability == 1.0
+        assert len(result.transitions) == 1
+        assert result.transitions[0].births == 0
+        assert result.transitions[0].deaths == 0
+
+    def test_small_migration(self):
+        pts1 = [(100, 100), (300, 300), (500, 500)]
+        pts2 = [(105, 105), (305, 305), (505, 505)]
+        result = temporal_analysis([pts1, pts2], match_radius=50.0)
+        assert result.num_snapshots == 2
+        assert result.overall_stability == 1.0
+        # All cells should be matched (no births/deaths)
+        assert result.transitions[0].births == 0
+        assert result.transitions[0].deaths == 0
+        # All cells migrated
+        migrate_events = [e for e in result.events if e.event_type == "migrate"]
+        assert len(migrate_events) >= 1
+
+    def test_birth_and_death(self):
+        pts1 = [(100, 100), (300, 300)]
+        pts2 = [(100, 100), (700, 700)]  # (300,300) dies, (700,700) born
+        result = temporal_analysis([pts1, pts2], match_radius=50.0)
+        births = [e for e in result.events if e.event_type == "birth"]
+        deaths = [e for e in result.events if e.event_type == "death"]
+        assert len(births) == 1
+        assert len(deaths) == 1
+        assert result.transitions[0].births == 1
+        assert result.transitions[0].deaths == 1
+
+    def test_three_snapshots(self):
+        pts1 = [(100, 100), (300, 300)]
+        pts2 = [(110, 110), (310, 310)]
+        pts3 = [(120, 120), (320, 320)]
+        result = temporal_analysis(
+            [pts1, pts2, pts3], match_radius=50.0
+        )
+        assert result.num_snapshots == 3
+        assert len(result.transitions) == 2
+
+    def test_growing_point_set(self):
+        pts1 = [(100, 100), (300, 300)]
+        pts2 = [(100, 100), (300, 300), (500, 500)]
+        pts3 = [(100, 100), (300, 300), (500, 500), (700, 700)]
+        result = temporal_analysis(
+            [pts1, pts2, pts3], match_radius=50.0
+        )
+        total_births = sum(t.births for t in result.transitions)
+        assert total_births == 2  # One birth per step
+
+    def test_shrinking_point_set(self):
+        pts1 = [(100, 100), (300, 300), (500, 500)]
+        pts2 = [(100, 100), (300, 300)]
+        result = temporal_analysis([pts1, pts2], match_radius=50.0)
+        assert result.transitions[0].deaths == 1
+
+    def test_complete_replacement(self):
+        pts1 = [(100, 100), (200, 200)]
+        pts2 = [(600, 600), (700, 700)]
+        result = temporal_analysis([pts1, pts2], match_radius=50.0)
+        assert result.transitions[0].births == 2
+        assert result.transitions[0].deaths == 2
+        assert result.overall_stability == 0.0
+
+    def test_match_radius_affects_matching(self):
+        pts1 = [(100, 100), (300, 300)]
+        pts2 = [(130, 130), (330, 330)]  # moved 42 units
+
+        # With large radius: matched
+        r1 = temporal_analysis([pts1, pts2], match_radius=100.0)
+        assert r1.transitions[0].deaths == 0
+
+        # With small radius: not matched
+        r2 = temporal_analysis([pts1, pts2], match_radius=10.0)
+        assert r2.transitions[0].deaths == 2
+
+    def test_validation_too_few_snapshots(self):
+        with pytest.raises(ValueError, match="At least 2"):
+            temporal_analysis([[(0, 0)]])
+
+    def test_validation_empty_snapshot(self):
+        with pytest.raises(ValueError, match="empty"):
+            temporal_analysis([[(0, 0)], []])
+
+
+# -- Trajectory tests -------------------------------------------------
+
+class TestTrajectories:
+    def test_stable_trajectory(self):
+        pts = [(100, 100), (300, 300)]
+        result = temporal_analysis([pts, pts, pts], match_radius=10.0)
+        # Should have 2 trajectories, each with lifespan 3
+        long_lived = [t for t in result.trajectories if t.lifespan == 3]
+        assert len(long_lived) == 2
+
+    def test_trajectory_lifespan(self):
+        pts1 = [(100, 100)]
+        pts2 = [(100, 100), (500, 500)]
+        pts3 = [(100, 100), (500, 500)]
+        result = temporal_analysis([pts1, pts2, pts3], match_radius=50.0)
+        lifespans = sorted([t.lifespan for t in result.trajectories])
+        assert 3 in lifespans  # original point lives all 3 steps
+        assert 2 in lifespans  # new point lives 2 steps
+
+    def test_trajectory_migration(self):
+        pts1 = [(100, 100)]
+        pts2 = [(110, 100)]
+        pts3 = [(120, 100)]
+        result = temporal_analysis([pts1, pts2, pts3], match_radius=50.0)
+        traj = result.trajectories[0]
+        assert abs(traj.total_migration - 20.0) < 1e-6
+        assert len(traj.positions) == 3
+
+    def test_trajectory_death_step(self):
+        pts1 = [(100, 100), (300, 300)]
+        pts2 = [(100, 100)]  # (300,300) dies
+        result = temporal_analysis([pts1, pts2], match_radius=50.0)
+        dead = [t for t in result.trajectories if t.death_step is not None]
+        assert len(dead) == 1
+        assert dead[0].death_step == 1
+
+    def test_trajectory_birth_step(self):
+        pts1 = [(100, 100)]
+        pts2 = [(100, 100), (500, 500)]
+        result = temporal_analysis([pts1, pts2], match_radius=50.0)
+        born_later = [t for t in result.trajectories if t.birth_step == 1]
+        assert len(born_later) == 1
+
+
+# -- Transition stats tests -------------------------------------------
+
+class TestTransitionStats:
+    def test_jaccard_identical(self):
+        pts = _make_grid(3, 100.0)
+        result = temporal_analysis([pts, pts], match_radius=10.0)
+        assert result.transitions[0].jaccard_index == 1.0
+
+    def test_jaccard_no_overlap(self):
+        pts1 = [(100, 100)]
+        pts2 = [(900, 900)]
+        result = temporal_analysis([pts1, pts2], match_radius=10.0)
+        assert result.transitions[0].jaccard_index == 0.0
+
+    def test_cell_counts(self):
+        pts1 = [(100, 100), (300, 300)]
+        pts2 = [(100, 100), (300, 300), (500, 500)]
+        result = temporal_analysis([pts1, pts2], match_radius=50.0)
+        assert result.transitions[0].total_cells_before == 2
+        assert result.transitions[0].total_cells_after == 3
+
+
+# -- Event type tests -------------------------------------------------
+
+class TestEventTypes:
+    def test_stable_event(self):
+        pts = [(100, 100), (300, 300)]
+        result = temporal_analysis([pts, pts], match_radius=10.0)
+        stable = [e for e in result.events if e.event_type == "stable"]
+        assert len(stable) == 2
+
+    def test_birth_event_fields(self):
+        pts1 = [(100, 100), (300, 300), (500, 100)]
+        pts2 = [(100, 100), (300, 300), (500, 100), (300, 100)]
+        result = temporal_analysis([pts1, pts2], match_radius=50.0)
+        births = [e for e in result.events if e.event_type == "birth"]
+        assert len(births) == 1
+        b = births[0]
+        assert b.prev_seed is None
+        assert b.area_before == 0.0
+        assert b.area_after >= 0  # may be 0 for edge cells
+        assert "New cell" in b.details
+
+    def test_death_event_fields(self):
+        pts1 = [(100, 100), (500, 500)]
+        pts2 = [(100, 100)]
+        result = temporal_analysis([pts1, pts2], match_radius=50.0)
+        deaths = [e for e in result.events if e.event_type == "death"]
+        assert len(deaths) == 1
+        d = deaths[0]
+        assert d.area_after == 0.0
+        assert "disappeared" in d.details
+
+
+# -- Summary tests ----------------------------------------------------
+
+class TestSummary:
+    def test_summary_contains_key_info(self):
+        pts1 = [(100, 100), (300, 300)]
+        pts2 = [(110, 110), (300, 300), (500, 500)]
+        result = temporal_analysis([pts1, pts2], match_radius=50.0)
+        summary = result.summary()
+        assert "Temporal Voronoi Analysis" in summary
+        assert "2 snapshots" in summary
+        assert "stability" in summary.lower()
+        assert "Births" in summary
+        assert "Deaths" in summary
+
+    def test_summary_empty_trajectories(self):
+        pts1 = [(100, 100)]
+        pts2 = [(900, 900)]
+        result = temporal_analysis([pts1, pts2], match_radius=10.0)
+        summary = result.summary()
+        assert "Temporal" in summary
+
+
+# -- Export tests -----------------------------------------------------
+
+class TestExportJSON:
+    def test_export_creates_file(self):
+        pts1 = [(100, 100), (300, 300)]
+        pts2 = [(110, 110), (310, 310)]
+        result = temporal_analysis([pts1, pts2], match_radius=50.0)
+
+        path = "_test_temporal_out.json"
+        try:
+            export_json(result, path)
+            assert os.path.exists(path)
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+            assert data["num_snapshots"] == 2
+            assert "events" in data
+            assert "transitions" in data
+            assert "trajectories" in data
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_export_event_structure(self):
+        pts1 = [(100, 100)]
+        pts2 = [(100, 100), (500, 500)]
+        result = temporal_analysis([pts1, pts2], match_radius=50.0)
+
+        path = "_test_temporal_ev.json"
+        try:
+            export_json(result, path)
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+            for ev in data["events"]:
+                assert "time_step" in ev
+                assert "event_type" in ev
+                assert "seed" in ev
+                assert "details" in ev
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+class TestExportCSV:
+    def test_export_creates_file(self):
+        pts1 = [(100, 100), (300, 300)]
+        pts2 = [(110, 110), (310, 310)]
+        result = temporal_analysis([pts1, pts2], match_radius=50.0)
+
+        path = "_test_temporal_out.csv"
+        try:
+            export_csv(result, path)
+            assert os.path.exists(path)
+            with open(path, encoding="utf-8") as f:
+                lines = f.readlines()
+            assert len(lines) >= 2  # header + at least 1 event
+            header = lines[0].strip()
+            assert "time_step" in header
+            assert "event_type" in header
+            assert "migration_dist" in header
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+# -- Data class tests -------------------------------------------------
+
+class TestDataClasses:
+    def test_cell_event_defaults(self):
+        e = CellEvent()
+        assert e.time_step == 0
+        assert e.event_type == ""
+        assert e.migration_dist == 0.0
+
+    def test_transition_stats_defaults(self):
+        t = TransitionStats()
+        assert t.births == 0
+        assert t.jaccard_index == 0.0
+
+    def test_cell_trajectory_defaults(self):
+        t = CellTrajectory()
+        assert t.positions == []
+        assert t.death_step is None
+        assert t.lifespan == 0
+
+    def test_temporal_result_defaults(self):
+        r = TemporalResult()
+        assert r.num_snapshots == 0
+        assert r.events == []
+        assert r.overall_stability == 0.0

--- a/vormap_temporal.py
+++ b/vormap_temporal.py
@@ -1,0 +1,713 @@
+"""Voronoi Temporal Dynamics -- track how diagrams evolve over time.
+
+Analyses sequences of point snapshots to identify cell birth, death,
+split, merge, migration, and area change events.  Useful for tracking
+facility movements, ecological territory shifts, urban growth, and
+any spatial process where Voronoi regions change over time.
+
+Usage::
+
+    from vormap_temporal import (
+        temporal_analysis, TemporalResult, CellEvent,
+    )
+
+    # Three time snapshots of point positions
+    snapshots = [
+        [(100, 200), (300, 400), (500, 100)],
+        [(110, 210), (300, 400), (500, 100), (700, 300)],
+        [(120, 220), (500, 100), (700, 300)],
+    ]
+    result = temporal_analysis(snapshots, match_radius=50.0)
+    print(result.summary())
+
+    for event in result.events:
+        print(f"t={event.time_step}: {event.event_type} at {event.seed}")
+
+    # CLI
+    python vormap_temporal.py snap1.txt snap2.txt snap3.txt --match-radius 50
+    python vormap_temporal.py snap1.txt snap2.txt --json temporal.json
+    python vormap_temporal.py snap1.txt snap2.txt --csv temporal.csv
+
+CLI supports 2+ snapshot files.  Each file uses the standard vormap
+point format (one ``x y`` pair per line).
+"""
+
+
+import json
+import sys
+import warnings
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+import vormap
+from vormap_geometry import polygon_area, edge_length
+from vormap_viz import compute_regions
+
+
+# -- Data classes -----------------------------------------------------
+
+@dataclass
+class CellEvent:
+    """A discrete event in the life of a Voronoi cell.
+
+    Attributes
+    ----------
+    time_step : int
+        0-based index of the transition (step i -> i+1).
+    event_type : str
+        One of: "birth", "death", "migrate", "grow", "shrink", "stable".
+    seed : tuple of (float, float)
+        Seed coordinates at the time of the event.
+    prev_seed : tuple of (float, float) or None
+        Seed coordinates at the previous step (None for births).
+    area_before : float
+        Cell area before the transition (0 for births).
+    area_after : float
+        Cell area after the transition (0 for deaths).
+    area_change : float
+        Absolute area change.
+    area_change_pct : float
+        Percentage area change relative to the before area.
+    migration_dist : float
+        Euclidean distance the seed moved between steps.
+    details : str
+        Human-readable description of the event.
+    """
+    time_step: int = 0
+    event_type: str = ""
+    seed: Tuple[float, float] = (0.0, 0.0)
+    prev_seed: Optional[Tuple[float, float]] = None
+    area_before: float = 0.0
+    area_after: float = 0.0
+    area_change: float = 0.0
+    area_change_pct: float = 0.0
+    migration_dist: float = 0.0
+    details: str = ""
+
+
+@dataclass
+class TransitionStats:
+    """Summary statistics for a single time step transition.
+
+    Attributes
+    ----------
+    step : int
+        0-based transition index (step i -> i+1).
+    births : int
+        Number of new cells appearing.
+    deaths : int
+        Number of cells disappearing.
+    migrations : int
+        Number of cells whose seed moved.
+    mean_migration : float
+        Average migration distance across all matched cells.
+    max_migration : float
+        Maximum migration distance.
+    mean_area_change_pct : float
+        Average absolute area change percentage.
+    total_cells_before : int
+        Number of cells at step i.
+    total_cells_after : int
+        Number of cells at step i+1.
+    jaccard_index : float
+        Set similarity of seeds between steps (intersection / union).
+    """
+    step: int = 0
+    births: int = 0
+    deaths: int = 0
+    migrations: int = 0
+    mean_migration: float = 0.0
+    max_migration: float = 0.0
+    mean_area_change_pct: float = 0.0
+    total_cells_before: int = 0
+    total_cells_after: int = 0
+    jaccard_index: float = 0.0
+
+
+@dataclass
+class CellTrajectory:
+    """The full trajectory of a single cell across all time steps.
+
+    Attributes
+    ----------
+    initial_seed : tuple of (float, float)
+        Seed position at first appearance.
+    birth_step : int
+        Time step when the cell first appeared.
+    death_step : int or None
+        Time step when the cell disappeared (None if still alive).
+    positions : list of (float, float)
+        Seed position at each step where the cell existed.
+    areas : list of float
+        Cell area at each step where the cell existed.
+    total_migration : float
+        Total cumulative distance the seed moved.
+    lifespan : int
+        Number of steps the cell existed.
+    """
+    initial_seed: Tuple[float, float] = (0.0, 0.0)
+    birth_step: int = 0
+    death_step: Optional[int] = None
+    positions: List[Tuple[float, float]] = field(default_factory=list)
+    areas: List[float] = field(default_factory=list)
+    total_migration: float = 0.0
+    lifespan: int = 0
+
+
+@dataclass
+class TemporalResult:
+    """Complete result of a temporal Voronoi analysis.
+
+    Attributes
+    ----------
+    num_snapshots : int
+        Number of input time snapshots.
+    events : list of CellEvent
+        All detected events across all transitions.
+    transitions : list of TransitionStats
+        Per-transition summary statistics.
+    trajectories : list of CellTrajectory
+        Per-cell trajectories across time.
+    overall_stability : float
+        0-1 score (1 = perfectly stable, 0 = completely different).
+    match_radius : float
+        Radius used for seed matching between steps.
+    """
+    num_snapshots: int = 0
+    events: List[CellEvent] = field(default_factory=list)
+    transitions: List[TransitionStats] = field(default_factory=list)
+    trajectories: List[CellTrajectory] = field(default_factory=list)
+    overall_stability: float = 0.0
+    match_radius: float = 0.0
+
+    def summary(self) -> str:
+        """Human-readable summary of the temporal analysis."""
+        lines = []
+        lines.append(f"Temporal Voronoi Analysis: {self.num_snapshots} snapshots")
+        lines.append(f"Match radius: {self.match_radius:.1f}")
+        lines.append(f"Overall stability: {self.overall_stability:.3f}")
+        lines.append("")
+
+        total_births = sum(t.births for t in self.transitions)
+        total_deaths = sum(t.deaths for t in self.transitions)
+        total_events = len(self.events)
+
+        lines.append(f"Total events: {total_events}")
+        lines.append(f"  Births: {total_births}")
+        lines.append(f"  Deaths: {total_deaths}")
+        lines.append(f"  Trajectories tracked: {len(self.trajectories)}")
+
+        if self.trajectories:
+            lifespans = [t.lifespan for t in self.trajectories]
+            mean_life = sum(lifespans) / len(lifespans)
+            max_life = max(lifespans)
+            lines.append(f"  Mean lifespan: {mean_life:.1f} steps")
+            lines.append(f"  Max lifespan: {max_life} steps")
+
+        lines.append("")
+        for ts in self.transitions:
+            lines.append(
+                f"Step {ts.step} -> {ts.step + 1}: "
+                f"{ts.total_cells_before} -> {ts.total_cells_after} cells, "
+                f"+{ts.births} -{ts.deaths}, "
+                f"Jaccard={ts.jaccard_index:.3f}"
+            )
+            if ts.mean_migration > 0:
+                lines.append(
+                    f"  Migration: mean={ts.mean_migration:.2f}, "
+                    f"max={ts.max_migration:.2f}"
+                )
+
+        return "\n".join(lines)
+
+
+# -- Helpers ----------------------------------------------------------
+
+def _euclidean(a, b):
+    """Euclidean distance between two 2D points."""
+    return edge_length(a, b)
+
+
+def _match_seeds(seeds_a, seeds_b, radius):
+    """Match seeds between two snapshots using nearest-neighbor within radius.
+
+    Uses a greedy closest-first matching strategy to avoid ambiguity.
+
+    Returns
+    -------
+    matches : dict
+        Maps index in seeds_a to index in seeds_b.
+    unmatched_a : list of int
+        Indices in seeds_a with no match (deaths).
+    unmatched_b : list of int
+        Indices in seeds_b with no match (births).
+    """
+    n_a = len(seeds_a)
+    n_b = len(seeds_b)
+
+    # Compute all pairwise distances within radius
+    candidates = []
+    for i in range(n_a):
+        for j in range(n_b):
+            d = _euclidean(seeds_a[i], seeds_b[j])
+            if d <= radius:
+                candidates.append((d, i, j))
+
+    # Greedy closest-first matching
+    candidates.sort()
+    matched_a = set()
+    matched_b = set()
+    matches = {}
+
+    for d, i, j in candidates:
+        if i in matched_a or j in matched_b:
+            continue
+        matches[i] = j
+        matched_a.add(i)
+        matched_b.add(j)
+
+    unmatched_a = [i for i in range(n_a) if i not in matched_a]
+    unmatched_b = [j for j in range(n_b) if j not in matched_b]
+
+    return matches, unmatched_a, unmatched_b
+
+
+def _get_cell_areas(points):
+    """Compute Voronoi cell areas for a set of points.
+
+    Returns a dict mapping *index* (int) to area, so that duplicate
+    seed coordinates are handled correctly.  When duplicates are
+    detected a warning is emitted.
+    """
+    if len(points) < 2:
+        return {}
+
+    # Warn on duplicate coordinates
+    seen = set()
+    for pt in points:
+        if pt in seen:
+            warnings.warn(
+                f"Duplicate seed coordinate {pt} detected; "
+                "area values for coincident seeds may be unreliable",
+                stacklevel=2,
+            )
+            break
+        seen.add(pt)
+
+    regions = compute_regions(points)
+    areas: Dict[int, float] = {}
+    for i, seed in enumerate(points):
+        if seed in regions:
+            areas[i] = polygon_area(regions[seed])
+        else:
+            areas[i] = 0.0
+    return areas
+
+
+# -- Core analysis ----------------------------------------------------
+
+def temporal_analysis(
+    snapshots,
+    *,
+    match_radius=50.0,
+    area_change_threshold=10.0,
+):
+    """Analyse how a Voronoi diagram evolves across time snapshots.
+
+    Parameters
+    ----------
+    snapshots : list of list of (x, y)
+        Two or more point-set snapshots in chronological order.
+    match_radius : float
+        Maximum distance to consider two seeds as the "same" cell
+        across consecutive snapshots.  Default 50.0.
+    area_change_threshold : float
+        Percentage area change below which a cell is considered
+        "stable" rather than "growing" or "shrinking".  Default 10.0.
+
+    Returns
+    -------
+    TemporalResult
+        Full analysis including events, transitions, and trajectories.
+
+    Raises
+    ------
+    ValueError
+        If fewer than 2 snapshots are provided or any snapshot is empty.
+    """
+    if len(snapshots) < 2:
+        raise ValueError("At least 2 snapshots required for temporal analysis")
+    for i, snap in enumerate(snapshots):
+        if not snap:
+            raise ValueError(f"Snapshot {i} is empty")
+
+    # Normalize points to tuples
+    norm_snapshots = [
+        [(float(p[0]), float(p[1])) for p in snap]
+        for snap in snapshots
+    ]
+
+    # Compute areas for each snapshot
+    snapshot_areas = [_get_cell_areas(snap) for snap in norm_snapshots]
+
+    all_events = []
+    all_transitions = []
+
+    # Track cell identity across steps
+    active_trajectories = {}
+    trajectories = []
+
+    # Initialize trajectories for first snapshot
+    for i, seed in enumerate(norm_snapshots[0]):
+        traj = CellTrajectory(
+            initial_seed=seed,
+            birth_step=0,
+            positions=[seed],
+            areas=[snapshot_areas[0].get(i, 0.0)],
+            lifespan=1,
+        )
+        trajectories.append(traj)
+        active_trajectories[i] = len(trajectories) - 1
+
+    # Process each transition
+    for step in range(len(norm_snapshots) - 1):
+        seeds_a = norm_snapshots[step]
+        seeds_b = norm_snapshots[step + 1]
+        areas_a = snapshot_areas[step]
+        areas_b = snapshot_areas[step + 1]
+
+        matches, deaths_idx, births_idx = _match_seeds(
+            seeds_a, seeds_b, match_radius
+        )
+
+        step_events = []
+        migration_dists = []
+        area_changes = []
+        new_active = {}
+
+        # Process matched cells
+        for idx_a, idx_b in matches.items():
+            seed_a = seeds_a[idx_a]
+            seed_b = seeds_b[idx_b]
+            area_a = areas_a.get(idx_a, 0.0)
+            area_b = areas_b.get(idx_b, 0.0)
+            dist = _euclidean(seed_a, seed_b)
+            migration_dists.append(dist)
+
+            a_change = area_b - area_a
+            a_change_pct = (
+                abs(a_change) / area_a * 100.0 if area_a > 0 else 0.0
+            )
+            area_changes.append(a_change_pct)
+
+            # Determine event type
+            if a_change_pct > area_change_threshold and a_change > 0:
+                event_type = "grow"
+                details = (
+                    f"Area grew {a_change_pct:.1f}% "
+                    f"({area_a:.1f} -> {area_b:.1f})"
+                )
+            elif a_change_pct > area_change_threshold and a_change < 0:
+                event_type = "shrink"
+                details = (
+                    f"Area shrank {a_change_pct:.1f}% "
+                    f"({area_a:.1f} -> {area_b:.1f})"
+                )
+            elif dist > 0.01:
+                event_type = "migrate"
+                details = f"Migrated {dist:.2f} units"
+            else:
+                event_type = "stable"
+                details = "No significant change"
+
+            step_events.append(CellEvent(
+                time_step=step,
+                event_type=event_type,
+                seed=seed_b,
+                prev_seed=seed_a,
+                area_before=area_a,
+                area_after=area_b,
+                area_change=a_change,
+                area_change_pct=a_change_pct,
+                migration_dist=dist,
+                details=details,
+            ))
+
+            # Update trajectory
+            traj_idx = active_trajectories.get(idx_a)
+            if traj_idx is not None:
+                traj = trajectories[traj_idx]
+                traj.positions.append(seed_b)
+                traj.areas.append(area_b)
+                traj.total_migration += dist
+                traj.lifespan += 1
+                new_active[idx_b] = traj_idx
+
+        # Process deaths
+        for idx_a in deaths_idx:
+            seed_a = seeds_a[idx_a]
+            area_a = areas_a.get(idx_a, 0.0)
+            step_events.append(CellEvent(
+                time_step=step,
+                event_type="death",
+                seed=seed_a,
+                prev_seed=seed_a,
+                area_before=area_a,
+                area_after=0.0,
+                area_change=-area_a,
+                area_change_pct=100.0,
+                migration_dist=0.0,
+                details=f"Cell disappeared (area was {area_a:.1f})",
+            ))
+            traj_idx = active_trajectories.get(idx_a)
+            if traj_idx is not None:
+                trajectories[traj_idx].death_step = step + 1
+
+        # Process births
+        for idx_b in births_idx:
+            seed_b = seeds_b[idx_b]
+            area_b = areas_b.get(idx_b, 0.0)
+            step_events.append(CellEvent(
+                time_step=step,
+                event_type="birth",
+                seed=seed_b,
+                prev_seed=None,
+                area_before=0.0,
+                area_after=area_b,
+                area_change=area_b,
+                area_change_pct=0.0,
+                migration_dist=0.0,
+                details=f"New cell appeared (area {area_b:.1f})",
+            ))
+            traj = CellTrajectory(
+                initial_seed=seed_b,
+                birth_step=step + 1,
+                positions=[seed_b],
+                areas=[area_b],
+                lifespan=1,
+            )
+            trajectories.append(traj)
+            new_active[idx_b] = len(trajectories) - 1
+
+        active_trajectories = new_active
+        all_events.extend(step_events)
+
+        # Compute transition statistics
+        mean_mig = (
+            sum(migration_dists) / len(migration_dists)
+            if migration_dists else 0.0
+        )
+        max_mig = max(migration_dists) if migration_dists else 0.0
+        mean_area_chg = (
+            sum(area_changes) / len(area_changes)
+            if area_changes else 0.0
+        )
+
+        intersection = len(matches)
+        union = len(seeds_a) + len(seeds_b) - intersection
+        jaccard = intersection / union if union > 0 else 1.0
+
+        all_transitions.append(TransitionStats(
+            step=step,
+            births=len(births_idx),
+            deaths=len(deaths_idx),
+            migrations=sum(1 for d in migration_dists if d > 0.01),
+            mean_migration=mean_mig,
+            max_migration=max_mig,
+            mean_area_change_pct=mean_area_chg,
+            total_cells_before=len(seeds_a),
+            total_cells_after=len(seeds_b),
+            jaccard_index=jaccard,
+        ))
+
+    # Overall stability: average Jaccard across transitions
+    overall = (
+        sum(t.jaccard_index for t in all_transitions) / len(all_transitions)
+        if all_transitions else 1.0
+    )
+
+    return TemporalResult(
+        num_snapshots=len(snapshots),
+        events=all_events,
+        transitions=all_transitions,
+        trajectories=trajectories,
+        overall_stability=overall,
+        match_radius=match_radius,
+    )
+
+
+# -- Export -----------------------------------------------------------
+
+def export_json(result, path):
+    """Export temporal analysis to JSON.
+
+    Parameters
+    ----------
+    result : TemporalResult
+        Output of ``temporal_analysis()``.
+    path : str
+        Output file path.
+    """
+    validated = vormap.validate_output_path(path)
+    data = {
+        "num_snapshots": result.num_snapshots,
+        "match_radius": result.match_radius,
+        "overall_stability": round(result.overall_stability, 4),
+        "events": [
+            {
+                "time_step": e.time_step,
+                "event_type": e.event_type,
+                "seed": list(e.seed),
+                "prev_seed": list(e.prev_seed) if e.prev_seed else None,
+                "area_before": round(e.area_before, 2),
+                "area_after": round(e.area_after, 2),
+                "area_change": round(e.area_change, 2),
+                "area_change_pct": round(e.area_change_pct, 2),
+                "migration_dist": round(e.migration_dist, 2),
+                "details": e.details,
+            }
+            for e in result.events
+        ],
+        "transitions": [
+            {
+                "step": t.step,
+                "births": t.births,
+                "deaths": t.deaths,
+                "migrations": t.migrations,
+                "mean_migration": round(t.mean_migration, 4),
+                "max_migration": round(t.max_migration, 4),
+                "mean_area_change_pct": round(t.mean_area_change_pct, 2),
+                "cells_before": t.total_cells_before,
+                "cells_after": t.total_cells_after,
+                "jaccard_index": round(t.jaccard_index, 4),
+            }
+            for t in result.transitions
+        ],
+        "trajectories": [
+            {
+                "initial_seed": list(tr.initial_seed),
+                "birth_step": tr.birth_step,
+                "death_step": tr.death_step,
+                "positions": [list(p) for p in tr.positions],
+                "areas": [round(a, 2) for a in tr.areas],
+                "total_migration": round(tr.total_migration, 2),
+                "lifespan": tr.lifespan,
+            }
+            for tr in result.trajectories
+        ],
+    }
+    with open(validated, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def export_csv(result, path):
+    """Export temporal events to CSV.
+
+    Parameters
+    ----------
+    result : TemporalResult
+        Output of ``temporal_analysis()``.
+    path : str
+        Output file path.
+    """
+    validated = vormap.validate_output_path(path)
+    with open(validated, "w", encoding="utf-8") as f:
+        f.write(
+            "time_step,event_type,seed_x,seed_y,"
+            "prev_seed_x,prev_seed_y,"
+            "area_before,area_after,area_change,area_change_pct,"
+            "migration_dist,details\n"
+        )
+        for e in result.events:
+            prev_x = e.prev_seed[0] if e.prev_seed else ""
+            prev_y = e.prev_seed[1] if e.prev_seed else ""
+            details = e.details.replace('"', '""')
+            f.write(
+                f"{e.time_step},{e.event_type},"
+                f"{e.seed[0]:.4f},{e.seed[1]:.4f},"
+                f"{prev_x},{prev_y},"
+                f"{e.area_before:.2f},{e.area_after:.2f},"
+                f"{e.area_change:.2f},{e.area_change_pct:.2f},"
+                f"{e.migration_dist:.4f},\"{details}\"\n"
+            )
+
+
+# -- CLI --------------------------------------------------------------
+
+def main(argv=None):
+    """CLI entry point for temporal Voronoi analysis.
+
+    Usage::
+
+        python vormap_temporal.py snap1.txt snap2.txt [snap3.txt ...] [options]
+
+    Options:
+        --match-radius R     Seed matching radius (default: 50.0)
+        --area-threshold P   Area change threshold % (default: 10.0)
+        --json FILE          Export results to JSON
+        --csv FILE           Export events to CSV
+    """
+    args = argv if argv is not None else sys.argv[1:]
+
+    snapshot_files = []
+    match_radius = 50.0
+    area_threshold = 10.0
+    json_path = None
+    csv_path = None
+
+    i = 0
+    while i < len(args):
+        if args[i] == "--match-radius" and i + 1 < len(args):
+            match_radius = float(args[i + 1])
+            i += 2
+        elif args[i] == "--area-threshold" and i + 1 < len(args):
+            area_threshold = float(args[i + 1])
+            i += 2
+        elif args[i] == "--json" and i + 1 < len(args):
+            json_path = args[i + 1]
+            i += 2
+        elif args[i] == "--csv" and i + 1 < len(args):
+            csv_path = args[i + 1]
+            i += 2
+        elif args[i].startswith("--"):
+            print(f"Unknown option: {args[i]}", file=sys.stderr)
+            sys.exit(1)
+        else:
+            snapshot_files.append(args[i])
+            i += 1
+
+    if len(snapshot_files) < 2:
+        print(
+            "Usage: python vormap_temporal.py snap1.txt snap2.txt "
+            "[snap3.txt ...] [--match-radius R] [--json FILE] [--csv FILE]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    snapshots = []
+    for filepath in snapshot_files:
+        validated = vormap.validate_input_path(filepath, allow_absolute=True)
+        data = vormap.load_data(validated)
+        points = [(d["x"], d["y"]) if isinstance(d, dict) else (d[0], d[1])
+                  for d in data]
+        snapshots.append(points)
+
+    result = temporal_analysis(
+        snapshots,
+        match_radius=match_radius,
+        area_change_threshold=area_threshold,
+    )
+
+    print(result.summary())
+
+    if json_path:
+        export_json(result, json_path)
+        print(f"\nJSON exported to: {json_path}")
+
+    if csv_path:
+        export_csv(result, csv_path)
+        print(f"\nCSV exported to: {csv_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #119. _get_cell_areas() now returns index-keyed dict instead of seed-tuple-keyed, preventing silent overwrite when seeds share coordinates. Adds duplicate warning and 2 new tests. All 46 tests pass.