### PR TITLE
perf: remove duplicate KDTree build in grid_interpolate

### DIFF
--- a/vormap_interp.py
+++ b/vormap_interp.py
@@ -312,11 +312,10 @@ def grid_interpolate(points, values, nx=50, ny=50, bounds=None,
     # ── Vectorized fast path for IDW/nearest with numpy + KDTree ────
     # Batch-query all grid points at once instead of calling interp_fn
     # in a Python loop.  On a 100x100 grid this is ~20-50x faster.
+    # Reuses the KDTree already built above to avoid O(n log n) duplicate.
     if _HAS_KDTREE and _HAS_SCIPY and method in ('idw', 'nearest'):
         import numpy as np
-        pts_array = np.array(points, dtype=float)
         vals_array = np.array(values, dtype=float)
-        tree = _KDTree(pts_array)
 
         # Build (ny*nx, 2) query matrix
         gx = np.array(x_coords, dtype=float)


### PR DESCRIPTION
Fixes #123

**Problem:** \grid_interpolate()\ builds a \cKDTree\ on line ~295 for the \interp_fn\ lambda, then builds a second identical tree on line ~319 in the vectorized fast path. The first tree and its closure are never used when the vectorized path runs (which it always does for idw/nearest when scipy is available).

**Fix:** Remove the redundant \_KDTree(pts_array)\ construction in the vectorized path and reuse the \	ree\ variable already in scope.

**Impact:** Eliminates an O(n log n) tree build and halves peak memory for the KDTree on every \grid_interpolate\ call with idw/nearest method.