### PR TITLE
perf: skip redundant KDTree build in grid_interpolate

### DIFF
--- a/vormap_interp.py
+++ b/vormap_interp.py
@@ -288,10 +288,12 @@ def grid_interpolate(points, values, nx=50, ny=50, bounds=None,
         areas_orig = _voronoi_cell_areas(pts_array)
         interp_fn = lambda q: _natural_neighbor_interp_precomputed(
             pts_array, areas_orig, values, q)
-    elif _HAS_KDTREE and method in ('nearest', 'idw'):
-        # Build KDTree once, share across all nx*ny grid queries.
-        # Reduces nearest from O(n*nx*ny) to O(nx*ny*log(n)),
-        # and IDW from O(n*nx*ny) to O(nx*ny*(log(n)+k)).
+    elif _HAS_KDTREE and _HAS_SCIPY and method in ('nearest', 'idw'):
+        # Vectorized fast path below will handle these; skip building a
+        # throwaway KDTree + interp_fn closure here (fixes issue #123).
+        interp_fn = None  # sentinel — vectorized path runs instead
+    elif method in ('nearest', 'idw') and _HAS_KDTREE:
+        # KDTree available but no scipy/numpy — scalar path with shared tree
         tree = _KDTree(points)
         if method == 'nearest':
             interp_fn = lambda q: nearest_interp(points, values, q,
@@ -306,7 +308,9 @@ def grid_interpolate(points, values, nx=50, ny=50, bounds=None,
             'nearest': lambda q: nearest_interp(points, values, q),
         }.get(method)
 
-    if interp_fn is None:
+    if interp_fn is None and not (
+        _HAS_KDTREE and _HAS_SCIPY and method in ('idw', 'nearest')
+    ):
         raise ValueError("method must be 'natural', 'idw', or 'nearest'")
 
     # ── Vectorized fast path for IDW/nearest with numpy + KDTree ────


### PR DESCRIPTION
Fixes #123

When method is idw or 
earest and both scipy and KDTree are available, grid_interpolate() was building a KDTree + interp_fn closure (lines ~293-300) that the vectorized fast path (line ~316) would immediately discard and rebuild. This wasted O(n log n) time and kept the unused tree in memory.

Fix: detect when the vectorized path will run and skip the initial build. The scalar fallback path still builds its own tree when numpy isn't available.

All 2514 tests pass.