### PR TITLE
security: fix XXE bypass in GPX parser fallback

### DIFF
--- a/test_gpx.py
+++ b/test_gpx.py
@@ -188,6 +188,29 @@ def test_file_not_found():
         pass
 
 
+def test_xxe_rejection_padded():
+    """Ensure DOCTYPE after >4KB of padding is still rejected."""
+    padding = b"<?xml version='1.0'?>\n" + b"<!-- " + b"A" * 8000 + b" -->\n"
+    malicious = padding + b"""<!DOCTYPE foo [
+      <!ENTITY xxe SYSTEM "file:///etc/passwd">
+    ]>
+    <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+      <wpt lat="0" lon="0"><name>&xxe;</name></wpt>
+    </gpx>"""
+    path = tempfile.mktemp(suffix=".gpx")
+    try:
+        with open(path, "wb") as f:
+            f.write(malicious)
+        try:
+            load_gpx(path)
+            assert False, "Should have raised ValueError for XXE"
+        except ValueError as e:
+            assert "DOCTYPE" in str(e) or "ENTITY" in str(e)
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
 if __name__ == "__main__":
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     for t in tests:

--- a/vormap_gpx.py
+++ b/vormap_gpx.py
@@ -52,11 +52,13 @@ def _safe_parse(filepath):
         return _SafeET.parse(filepath)
 
     # Fallback: use iterparse and reject any DOCTYPE / entity declarations
-    # by pre-scanning the first 4 KB for risky preambles.
+    # by scanning the entire file for risky preambles.  Earlier versions
+    # only checked the first 4 KB which could be bypassed by padding the
+    # file with whitespace or comments before the DOCTYPE.
     with open(filepath, "rb") as fh:
-        head = fh.read(4096)
-    head_lower = head.lower()
-    if b"<!entity" in head_lower or b"<!doctype" in head_lower:
+        content = fh.read()
+    content_lower = content.lower()
+    if b"<!entity" in content_lower or b"<!doctype" in content_lower:
         raise ValueError(
             "GPX file contains a DOCTYPE or ENTITY declaration — "
             "refusing to parse (possible XXE attack). "


### PR DESCRIPTION
## What

Fixes a security bypass in the GPX XML parser's fallback path (when defusedxml is not installed).

## Why

The _safe_parse() function only scanned the first 4KB of the file for <!DOCTYPE and <!ENTITY markers. An attacker could bypass this check by padding the GPX file with >4KB of whitespace or XML comments before the malicious declarations, allowing XXE (XML External Entity) attacks.

## Changes

- **Full file scan** — now reads and checks the entire file content instead of just the first 4KB
- **New test** — 	est_xxe_rejection_padded() verifies that DOCTYPE declarations hidden after 8KB of padding are correctly rejected

## Risk

Low — the fallback path only activates when defusedxml is not installed. The fix is a minimal change (read entire file vs first 4KB). For large GPX files this adds a small memory overhead, but security correctness is more important.