### PR TITLE
Preserve global RNG state in demo entry points

### DIFF
--- a/tests/test_demo_rng_isolation.py
+++ b/tests/test_demo_rng_isolation.py
@@ -1,0 +1,83 @@
+"""Regression tests for demo functions preserving host RNG state."""
+
+import contextlib
+import io
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def _run_silently(func):
+    with contextlib.redirect_stdout(io.StringIO()):
+        return func()
+
+
+def _assert_preserves_global_rng(func):
+    random.seed(99)
+    state = random.getstate()
+
+    _run_silently(func)
+
+    assert random.getstate() == state
+
+
+def test_attention_demo_preserves_global_rng(tmp_path, monkeypatch):
+    from vormap_attention import attention_demo
+
+    monkeypatch.chdir(tmp_path)
+
+    _assert_preserves_global_rng(attention_demo)
+
+
+def test_dispatch_demo_preserves_global_rng(tmp_path, monkeypatch):
+    from vormap_dispatch import demo
+
+    monkeypatch.chdir(tmp_path)
+
+    _assert_preserves_global_rng(demo)
+
+
+def test_forensics_demo_preserves_global_rng():
+    from vormap_forensics import forensics_demo
+
+    _assert_preserves_global_rng(forensics_demo)
+
+
+def test_guardian_demo_preserves_global_rng():
+    from vormap_guardian import _run_demo
+
+    _assert_preserves_global_rng(_run_demo)
+
+
+def test_negotiator_demo_preserves_global_rng():
+    from vormap_negotiator import _demo
+
+    _assert_preserves_global_rng(_demo)
+
+
+def test_nervous_demo_preserves_global_rng():
+    from vormap_nervous import nervous_demo
+
+    _assert_preserves_global_rng(nervous_demo)
+
+
+def test_resilience_demo_preserves_global_rng():
+    from vormap_resilience import _demo
+
+    _assert_preserves_global_rng(_demo)
+
+
+def test_strategist_demo_preserves_global_rng(tmp_path, monkeypatch):
+    import vormap_strategist
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        vormap_strategist,
+        "__file__",
+        str(tmp_path / "vormap_strategist.py"),
+    )
+    monkeypatch.setattr(vormap_strategist, "export_html", lambda plan, path: None)
+
+    _assert_preserves_global_rng(vormap_strategist._demo)

--- a/vormap_attention.py
+++ b/vormap_attention.py
@@ -272,7 +272,7 @@ def _strategic_importance(points: List[Tuple[float, float]],
 
     betweenness = [0.0] * n
     sample_size = min(20, n)
-    sources = random.sample(range(n), sample_size)
+    sources = random.Random(0).sample(range(n), sample_size)
 
     for s in sources:
         # BFS from s
@@ -720,18 +720,18 @@ def attention_analyze(path_or_points, top_k: int = 10, **kwargs) -> AttentionRes
 
 def attention_demo():
     """Generate random points and run full analysis."""
-    random.seed(42)
+    rng = random.Random(42)
     # Create clustered point pattern
     points = []
     # Cluster 1
     for _ in range(15):
-        points.append((random.gauss(20, 3), random.gauss(20, 3)))
+        points.append((rng.gauss(20, 3), rng.gauss(20, 3)))
     # Cluster 2
     for _ in range(10):
-        points.append((random.gauss(60, 5), random.gauss(50, 5)))
+        points.append((rng.gauss(60, 5), rng.gauss(50, 5)))
     # Scattered
     for _ in range(8):
-        points.append((random.uniform(0, 80), random.uniform(0, 80)))
+        points.append((rng.uniform(0, 80), rng.uniform(0, 80)))
     # Outlier
     points.append((90, 90))
 

--- a/vormap_dispatch.py
+++ b/vormap_dispatch.py
@@ -400,25 +400,25 @@ def read_csv_points(path):
 
 def demo():
     """Run demo with synthetic data."""
-    random.seed(42)
+    rng = random.Random(42)
     # Generate clustered facilities
     facilities = []
     for _ in range(25):
-        facilities.append((random.uniform(5, 95), random.uniform(5, 95)))
+        facilities.append((rng.uniform(5, 95), rng.uniform(5, 95)))
 
     # Generate demand points with clusters (simulating population centers)
     demands = []
     weights = []
     centers = [(20, 20), (80, 30), (50, 70), (30, 80), (75, 75)]
     for _ in range(500):
-        if random.random() < 0.7:
+        if rng.random() < 0.7:
             # Clustered demand
-            cx, cy = random.choice(centers)
-            demands.append((cx + random.gauss(0, 10), cy + random.gauss(0, 10)))
+            cx, cy = rng.choice(centers)
+            demands.append((cx + rng.gauss(0, 10), cy + rng.gauss(0, 10)))
         else:
             # Uniform demand
-            demands.append((random.uniform(0, 100), random.uniform(0, 100)))
-        weights.append(random.uniform(0.5, 2.0))
+            demands.append((rng.uniform(0, 100), rng.uniform(0, 100)))
+        weights.append(rng.uniform(0.5, 2.0))
 
     # Compute auto capacity
     total_weight = sum(weights)

--- a/vormap_forensics.py
+++ b/vormap_forensics.py
@@ -1057,20 +1057,20 @@ def investigate(source, grid_resolution: int = 20) -> ForensicVerdict:
 
 def forensics_demo():
     """Generate demo data with known anomalies and investigate it."""
-    random.seed(42)
+    rng = random.Random(42)
     pts = []
 
     # Base uniform-ish scatter
     for _ in range(200):
-        pts.append((random.uniform(50, 950), random.uniform(50, 950)))
+        pts.append((rng.uniform(50, 950), rng.uniform(50, 950)))
 
     # Inject tight cluster (intentional injection)
     for _ in range(15):
-        pts.append((500 + random.gauss(0, 3), 500 + random.gauss(0, 3)))
+        pts.append((500 + rng.gauss(0, 3), 500 + rng.gauss(0, 3)))
 
     # Inject boundary accumulation
     for _ in range(30):
-        pts.append((random.uniform(0, 5), random.uniform(0, 1000)))
+        pts.append((rng.uniform(0, 5), rng.uniform(0, 1000)))
 
     # Inject grid-aligned points (equipment artifact)
     for gx in range(0, 100, 10):

--- a/vormap_guardian.py
+++ b/vormap_guardian.py
@@ -768,12 +768,12 @@ def guard(source, constraints=None, auto_repair=False, max_iterations=5):
 
 def _run_demo():
     """Generate a demo with deliberate violations and auto-repair."""
-    random.seed(42)
+    rng = random.Random(42)
     points = []
 
     # Cluster of well-spaced points
     for _ in range(80):
-        points.append((random.uniform(100, 900), random.uniform(100, 900)))
+        points.append((rng.uniform(100, 900), rng.uniform(100, 900)))
 
     # Deliberately close pairs (MinSpacing violations)
     points.append((500.0, 500.0))

--- a/vormap_negotiator.py
+++ b/vormap_negotiator.py
@@ -1061,13 +1061,13 @@ svg{{display:block;margin:8px auto}}
 
 def _demo():
     """Run a demo negotiation on generated points."""
-    random.seed(42)
+    rng = random.Random(42)
     # Create a deliberately conflicted layout
     points = []
     # Cluster of crowded points near centre
     for _ in range(6):
-        points.append((500 + random.uniform(-30, 30),
-                        500 + random.uniform(-30, 30)))
+        points.append((500 + rng.uniform(-30, 30),
+                        500 + rng.uniform(-30, 30)))
     # Scattered outliers
     points.append((50, 50))
     points.append((950, 950))
@@ -1075,7 +1075,7 @@ def _demo():
     points.append((950, 50))
     # Mid-range points
     for _ in range(8):
-        points.append((random.uniform(100, 900), random.uniform(100, 900)))
+        points.append((rng.uniform(100, 900), rng.uniform(100, 900)))
 
     print("=" * 60)
     print("  SPATIAL CONFLICT NEGOTIATOR — DEMO")

--- a/vormap_nervous.py
+++ b/vormap_nervous.py
@@ -944,8 +944,8 @@ def nervous_analyze(
 
 def nervous_demo() -> NervousSystemResult:
     """Run a demo with sample points."""
-    random.seed(42)
-    pts = [(random.uniform(0, 100), random.uniform(0, 100)) for _ in range(25)]
+    rng = random.Random(42)
+    pts = [(rng.uniform(0, 100), rng.uniform(0, 100)) for _ in range(25)]
     engine = NervousSystemEngine(points=pts)
     result = engine.analyze()
     engine.print_report()

--- a/vormap_resilience.py
+++ b/vormap_resilience.py
@@ -875,7 +875,7 @@ def analyze_resilience(
 
 def _demo():
     """Run a demo with synthetic data."""
-    random.seed(42)
+    rng = random.Random(42)
     # Create a pattern with obvious vulnerability: one central hub
     points = [(500.0, 500.0)]  # central hub
     for angle_deg in range(0, 360, 45):
@@ -885,7 +885,7 @@ def _demo():
         points.append((x, y))
     # Add some random peripheral points
     for _ in range(12):
-        points.append((random.uniform(100, 900), random.uniform(100, 900)))
+        points.append((rng.uniform(100, 900), rng.uniform(100, 900)))
 
     ra = ResilienceAnalyzer(points)
     result = ra.analyze(cascade_depth=3, suggest_redundancy=True, top_k=5)

--- a/vormap_strategist.py
+++ b/vormap_strategist.py
@@ -712,12 +712,12 @@ def _html_round(r, idx):
 # ---------------------------------------------------------------------------
 
 def _demo():
-    random.seed(42)
+    rng = random.Random(42)
     # Create an intentionally imbalanced distribution
     pts = []
     # Cluster in bottom-left
     for _ in range(8):
-        pts.append((random.uniform(1, 3), random.uniform(1, 3)))
+        pts.append((rng.uniform(1, 3), rng.uniform(1, 3)))
     # Sparse top-right
     pts.append((8, 8))
     pts.append((9, 7))


### PR DESCRIPTION
## Summary
- Replace hard-coded global random.seed(42) demo setup with local random.Random(42) generators across the affected demo entry points
- Make attention strategic-importance sampling use a local deterministic generator instead of consuming the process-level RNG
- Add regression coverage asserting demo calls preserve the host application's global random state

Fixes #192.

## Tests
- uv run --extra dev pytest tests/test_demo_rng_isolation.py test_vormap_attention.py tests/test_dispatch.py tests/test_forensics.py tests/test_guardian.py tests/test_negotiator.py test_vormap_nervous.py tests/test_resilience.py -q
- python3 -m py_compile tests/test_demo_rng_isolation.py vormap_attention.py vormap_dispatch.py vormap_forensics.py vormap_guardian.py vormap_negotiator.py vormap_nervous.py vormap_resilience.py vormap_strategist.py